### PR TITLE
Fix edge case crash when there are no loaded chunks (e.g. on world load)

### DIFF
--- a/src/main/java/org/jurassicraft/server/event/ServerEventHandler.java
+++ b/src/main/java/org/jurassicraft/server/event/ServerEventHandler.java
@@ -76,24 +76,32 @@ public class ServerEventHandler {
 
     @SubscribeEvent
     public static void tickEvent(TickEvent.WorldTickEvent event) {
-        if (event.world.getTotalWorldTime() % 20 == 0) {
-            WorldServer world = event.world.getMinecraftServer().getWorld(0);
-            Chunk[] chunklist = world.getChunkProvider().getLoadedChunks().toArray(new Chunk[0]);
-            int randomChunk = ThreadLocalRandom.current().nextInt(0, chunklist.length);
+        if (event.world.getTotalWorldTime() % 20 != 0) {
+            return;
+        }
 
-            Random random = new Random();
-            int zeroX = chunklist[randomChunk].getPos().getXStart() + random.nextInt(16);
-            int zeroZ = chunklist[randomChunk].getPos().getZStart() + random.nextInt(16);
-            BlockPos.MutableBlockPos mutualBlockPos;
+        // sanity check in case no chunks are loaded
+        // (e.g. right after world load in some edge cases)
+        if (chunklist.length == 0) {
+            return;
+        }
+        
+        WorldServer world = event.world.getMinecraftServer().getWorld(0);
+        Chunk[] chunklist = world.getChunkProvider().getLoadedChunks().toArray(new Chunk[0]);
+        int randomChunk = ThreadLocalRandom.current().nextInt(0, chunklist.length);
 
-            if(!(world.getBiomeForCoordsBody(mutualBlockPos = new BlockPos.MutableBlockPos(zeroX, 0, zeroZ)) instanceof BiomeSwamp))
-                return;
+        Random random = new Random();
+        int zeroX = chunklist[randomChunk].getPos().getXStart() + random.nextInt(16);
+        int zeroZ = chunklist[randomChunk].getPos().getZStart() + random.nextInt(16);
+        BlockPos.MutableBlockPos mutualBlockPos;
 
-            for (int i = 255; i > -1; i--) {
-                if (world.getBlockState(mutualBlockPos.setPos(zeroX, i, zeroZ)).getBlock() instanceof BlockDirt && world.getBlockState(mutualBlockPos.setPos(zeroX, i + 1, zeroZ)).getBlock() instanceof BlockGrass) {
-                    world.setBlockState(mutualBlockPos.setPos(zeroX, i, zeroZ), BlockHandler.PEAT.getDefaultState());
-                    break;
-                }
+        if(!(world.getBiomeForCoordsBody(mutualBlockPos = new BlockPos.MutableBlockPos(zeroX, 0, zeroZ)) instanceof BiomeSwamp))
+            return;
+
+        for (int i = 255; i > -1; i--) {
+            if (world.getBlockState(mutualBlockPos.setPos(zeroX, i, zeroZ)).getBlock() instanceof BlockDirt && world.getBlockState(mutualBlockPos.setPos(zeroX, i + 1, zeroZ)).getBlock() instanceof BlockGrass) {
+                world.setBlockState(mutualBlockPos.setPos(zeroX, i, zeroZ), BlockHandler.PEAT.getDefaultState());
+                break;
             }
         }
     }


### PR DESCRIPTION
Apparently, the tickEvent handles circumstantial conversion from dirt to peat in loaded chunks. When there are no loaded chunks, it should have no effect, acting much like a no-op.

What used to happen instead is that, if there are no loaded chunks (possible e.g. when loading a save under certain rare circumstances or with some other mods), it would crash, as it would try to get a random integer between 0 and 0, and Java's Random throws an error when that happens.

By preventing the block with the random call from executing altogether in this scenario, this one error scenario is completely thwarted. The function has also been slightly refactored so that conditions like this are at the top of the function, to reduce nested indentation and make it easier for new early return conditions to be added in the future if needed. 